### PR TITLE
Remove deprecated is_admin field

### DIFF
--- a/lib/uro/accounts/user.ex
+++ b/lib/uro/accounts/user.ex
@@ -19,7 +19,6 @@ defmodule Uro.Accounts.User do
     field :email_notifications, :boolean
 
     field :profile_picture, :string
-    field :is_admin, :boolean, default: false
 
     has_one :user_privilege_ruleset, Uro.Accounts.UserPrivilegeRuleset, foreign_key: :user_id
 

--- a/priv/repo/migrations/20220629085250_remove_is_admin_from_users.exs
+++ b/priv/repo/migrations/20220629085250_remove_is_admin_from_users.exs
@@ -1,0 +1,15 @@
+defmodule Uro.Repo.Migrations.RemoveIsAdminFromUsers do
+  use Ecto.Migration
+
+  def down do
+    alter table(:users) do
+      add :is_admin, :boolean
+    end
+  end
+
+  def up do
+    alter table(:users) do
+      remove :is_admin
+    end
+  end
+end


### PR DESCRIPTION
is_admin was moved to the user_privilege_ruleset, so it's not needed in the user database anymore