### PR TITLE
WIP: fixes non html email link

### DIFF
--- a/lib/uro_web/templates/pow_email_confirmation/mailer/email_confirmation.text.eex
+++ b/lib/uro_web/templates/pow_email_confirmation/mailer/email_confirmation.text.eex
@@ -2,4 +2,4 @@ Hi,
 
 Please use the following link to confirm your e-mail address:
 
-<%= @url %>
+<%= content_tag(:p, link(@url, to: @url)) %>


### PR DESCRIPTION
I haven't tested it yet, but this looks like a thing that might be breaking non-html emails.