### PR TITLE
Fix docker development image, add env validation and small fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,14 +5,17 @@
 # have been pre-filled with default values for development.
 #
 
+# Base url
+BASE_URL=https://vsekai.local
+
 # Root-most origin, used for cookies, all subdomains will be able to access this cookie.
 # This should be the same as `PUBLIC_FRONTEND_URL`, but without the path.
-ROOT_ORIGIN=https://vsekai.local
+ROOT_ORIGIN=${BASE_URL}
 
 # Public URLs, used for redirects, etc, must be publicly accessible.
 # Both of these must be either a subdomain or the same domain as `PUBLIC_ROOT_ORIGIN`.
-URL=https://vsekai.local/api/v1/
-FRONTEND_URL=https://vsekai.local/
+URL=${BASE_URL}/api/v1/
+FRONTEND_URL=${BASE_URL}/
 
 # Persistent storage connections.
 DATABASE_URL=postgresql://vsekai:vsekai@database:5432/vsekai

--- a/Caddyfile.development
+++ b/Caddyfile.development
@@ -1,0 +1,24 @@
+{
+    debug
+    auto_https disable_redirects
+}
+
+http://vsekai.local {
+	handle_path /api/v1/* {
+		reverse_proxy uro:4000
+	}
+
+	handle_path /* {
+		reverse_proxy nextjs:3000
+	}
+}
+
+https://vsekai.local {
+	handle_path /api/v1/* {
+		reverse_proxy uro:4000
+	}
+
+	handle_path /* {
+		reverse_proxy nextjs:3000
+	}
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ Server will be available at **http://vsekai.local**
 
 Auto generated root CA will be in `./caddy/data/caddy/pki/authorities/local/root.crt` after you run `docker compose up`.
 
+When using default `docker compose up`, installing root certificate is **required** to connect V-Sekai game client. 
+If you want to test without **TLS**, use `docker-compose.development.yml` and connect client to port 80.
+
+**(Optional) Install root CA on Ubuntu/Debian**
+```
+sudo mkdir -p /usr/local/share/ca-certificates/vsekai-caddy
+sudo cp ./caddy/data/caddy/pki/authorities/local/root.crt /etc/ssl/certs/
+sudo bash -c 'echo "vsekai-caddy/root.crt" >> /etc/ca-certificates.conf'
+sudo update-ca-certificates
+```
+
+**(Optional) Add test admin with all permissions**
+```
+# username: adminuser
+# password: adminpassword
+URO_ID=$( docker ps --format "{{.ID}} {{.Image}}" | awk '$2 ~ /^.*-uro/ {print $1}' )
+docker exec ${URO_ID} mix run priv/repo/test_seeds.exs
+```
+
 ## Contributing
 
 ### Setup
@@ -46,8 +65,12 @@ To run the entire stack locally with Docker in **development** mode, use the com
 ```
 docker compose -f docker-compose.development.yml up
 ```
+**Development image additional features**
+- Extended debug logging for Uro, Nextjs, Caddy
+- Local **Mailbox** page to test email signup at http://vsekai.local/api/v1/mailbox
+- HTTP server (TLS disabled) on port 80
 
-By default, the stack uses [Caddy](https://caddyserver.com/) as a reverse proxy and is accessible at http://vsekai.local. You can adjust the values by setting the `ROOT_ORIGIN`, `URL`, and `FRONTEND_URL` environment variables in `.env` and `NEXT_PUBLIC_ORIGIN`, `NEXT_PUBLIC_API_ORIGIN` in `frontend/.env`. Also you will need to set it in `Caddyfile`.
+By default, the stack uses [Caddy](https://caddyserver.com/) as a reverse proxy and is accessible at http://vsekai.local. You can adjust the values by setting `BASE_URL` environment variable in `.env` and `NEXT_BASE_URL` in `frontend/.env`. Also you will need to set it in `Caddyfile`.
 
 If you want to configure **captcha** for registration, you need to set `TURNSTILE_SECRET_KEY` and `NEXT_PUBLIC_TURNSTILE_SITEKEY` ([Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/get-started/))
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -103,12 +103,7 @@ config :uro, :stale_shard_cutoff,
 
 config :uro, :stale_shard_interval, 30 * 24 * 60 * 60 * 1000
 
-config :uro, Uro.Turnstile,
-  secret_key:
-    get_optional_env.("TURNSTILE_SECRET_KEY") ||
-      Logger.warning(
-        "Turnstile (a reCaptcha alternative) is disabled because the environment variable TURNSTILE_SECRET_KEY is not set. For more information, see https://developers.cloudflare.com/turnstile/get-started/."
-      )
+config :uro, Uro.Turnstile, secret_key: get_optional_env.("TURNSTILE_SECRET_KEY")
 
 config :uro, :pow,
   user: Uro.Accounts.User,

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -11,6 +11,16 @@ services:
       - ./lib:/app/lib
       - ./config:/app/config
       - ./priv:/app/priv
+    links:
+      - database
+      - redis
+    depends_on:
+      database:
+        condition: service_healthy
+        restart: true
+      redis:
+        condition: service_healthy
+        restart: true
 
   nextjs:
     extends:
@@ -19,10 +29,9 @@ services:
     build:
       args:
         NODE_ENV: development
-    entrypoint: npm run dev
     user: "root"
-    volumes:
-      - ./frontend:/app
+    depends_on:
+      - uro
 
   database:
     extends:
@@ -38,6 +47,11 @@ services:
     extends:
       file: docker-compose.yml
       service: caddy
+    volumes:
+      - ./Caddyfile.development:/etc/caddy/Caddyfile
+    depends_on:
+      - uro
+      - nextjs
 
 networks:
   uro:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
   uro:
     build:
       context: .
+      args:
+        MIX_ENV: prod
       tags:
         - "uro:latest"
     restart: always

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,7 +1,9 @@
-NEXT_PUBLIC_ORIGIN=https://vsekai.local
+NEXT_BASE_URL=https://vsekai.local
+
+NEXT_PUBLIC_ORIGIN=${NEXT_BASE_URL}
 
 API_ORIGIN=http://uro:4000
-NEXT_PUBLIC_API_ORIGIN=https://vsekai.local/api/v1
+NEXT_PUBLIC_API_ORIGIN=${NEXT_BASE_URL}/api/v1
 
 # Cloudflare Turnstile captcha
 # Currently set to "Always pass" testing key.

--- a/lib/uro/application.ex
+++ b/lib/uro/application.ex
@@ -1,3 +1,5 @@
+require Logger
+
 defmodule Uro.Application do
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
@@ -6,6 +8,8 @@ defmodule Uro.Application do
   use Application
 
   def start(_type, _args) do
+    validate_env()
+
     children =
       if System.get_env("MINIMAL_START") == "true",
         do: [],
@@ -21,6 +25,27 @@ defmodule Uro.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Uro.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp validate_env do
+    env_vars = ["TURNSTILE_SECRET_KEY"]
+
+    for var <- env_vars do
+      err_msg =
+        case var do
+          "TURNSTILE_SECRET_KEY" ->
+            "Turnstile (a reCaptcha alternative) is disabled because the environment variable TURNSTILE_SECRET_KEY is not set. For more information, see https://developers.cloudflare.com/turnstile/get-started/."
+
+          _ ->
+            "Environment variable #{var} is not set"
+        end
+
+      case System.get_env(var) do
+        "" -> Logger.warning(err_msg)
+        nil -> Logger.warning(err_msg)
+        _ -> Logger.info("Environment variable #{var} is set")
+      end
+    end
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/uro/router.ex
+++ b/lib/uro/router.ex
@@ -28,6 +28,13 @@ defmodule Uro.Router do
     plug(Pow.Plug.RequireAuthenticated, error_handler: Uro.FallbackController)
   end
 
+  pipe_through([:api])
+
+  get("/health", Uro.HealthController, :index)
+
+  get("/openapi", OpenApiSpex.Plug.RenderSpec, [])
+  get("/docs", Uro.OpenAPI.Viewer, [])
+
   if Mix.env() == :dev do
     pipeline :browser do
       plug(:accepts, ["html"])
@@ -43,13 +50,6 @@ defmodule Uro.Router do
       forward("/mailbox", Plug.Swoosh.MailboxPreview)
     end
   end
-
-  pipe_through([:api])
-
-  get("/health", Uro.HealthController, :index)
-
-  get("/openapi", OpenApiSpex.Plug.RenderSpec, [])
-  get("/docs", Uro.OpenAPI.Viewer, [])
 
   scope "/session" do
     pipe_through([:authenticated])


### PR DESCRIPTION
**General fixes**
- Fixed `config/prod.exs` not loading (MIX_ENV=prod was not set)
- Interpolate variables in **.env** files for easier configuration
- Move env variable validation after application startup, since .env variables are not available at **build time** in Docker.
- Update Quick Setup instructions

**Development image fixes**
- Remove frontend `volume` mount that triggered build failure. `frontend/` folder in docker image was replaced by docker-compose when mounting, so node modules installed in image were removed. 
- Removed frontend `entrypoint` override that caused failure on image run
- Fix missing `depends_on`, `links` causing build failure. In docker-compose files, `extends` won't extend some properties (see [Restrictions section](https://docs.docker.com/reference/compose-file/services/#extends))
- Add development Caddyfile to enable HTTP without TLS server on port 80 for testing
- `/mailbox` load failed with a **401** error. As a temporary fix it was moved to `/api/v1/mailbox` path, but this issue needs review.
