### PR TITLE
Implements admin/avatar/maps/profile/session/shards/registration apis and small fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ JOKEN_SIGNER=gqawCOER09ZZjaN8W2QM9XT9BeJSZ9qc
 # https://developers.cloudflare.com/turnstile/get-started/
 TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 
+# Signup key to send signup requests from Game client
+SIGNUP_API_KEY=eNoZ4kXHgT0z9ZTYGsq7eE0rQYvR6YBi
+
 OAUTH2_GITHUB_STRATEGY=Assent.Strategy.Github
 OAUTH2_GITHUB_CLIENT_ID=
 OAUTH2_GITHUB_CLIENT_SECRET=

--- a/Caddyfile
+++ b/Caddyfile
@@ -3,6 +3,10 @@ vsekai.local {
 		reverse_proxy uro:4000
 	}
 
+	handle /uploads/* {
+		reverse_proxy uro:4000
+	}
+
 	handle_path /* {
 		reverse_proxy nextjs:3000
 	}

--- a/config/config.exs
+++ b/config/config.exs
@@ -155,6 +155,11 @@ config :logger, :console,
 
 config :phoenix, :json_library, Jason
 
+config :waffle,
+  storage: Waffle.Storage.Local
+
+# storage_dir: "uploads"
+
 import_config "#{Mix.env()}.exs"
 
 if Mix.env() == "dev" do

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,6 +1,10 @@
 import Config
 
-config :uro, Uro.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"
+# Unused (no static files)
+# config :uro, Uro.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"
+
+# TODO: Replace with correct adapter in production
+config :uro, Uro.Mailer, adapter: Swoosh.Adapters.Local
 
 # Do not print debug messages in production.
 config :logger, level: :info

--- a/frontend/src/app/(public)/admin/data.ts
+++ b/frontend/src/app/(public)/admin/data.ts
@@ -1,0 +1,32 @@
+import { skipToken, useSuspenseQuery } from "@tanstack/react-query";
+
+import {
+	type api,
+	getAdminStatus
+} from "~/api";
+import { useOptionalSession } from "~/hooks/session";
+import { getQueryClient } from "~/query";
+
+export function useAdminStatus() {
+	const session = useOptionalSession();
+
+	const { data: admin_status = null } = useSuspenseQuery({
+		queryFn:
+			async ({ signal }) => {
+					const { data, error, response } = await getAdminStatus({
+						signal
+					});
+
+					if (response.status === 404) return null;
+					if (error) throw error;
+					return data;
+				},
+		queryKey: ["adminStatus"]
+	});
+
+	if (!admin_status) return null;
+
+	return {
+		...admin_status,
+	};
+}

--- a/frontend/src/app/(public)/admin/page.tsx
+++ b/frontend/src/app/(public)/admin/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { VSekaiMark } from "~/components/vsekai-mark";
+import { useReturnIntent } from "~/hooks/return-intent";
+import { restoreReturnIntent } from "~/hooks/return-intent/common";
+import { useAdminStatus } from "./data";
+
+export default function AdminStatusPage() {
+	const adminStatus = useAdminStatus();
+	const { returnIntent } = useReturnIntent();
+
+	if (adminStatus?.status?.is_admin == 'false')
+		restoreReturnIntent(returnIntent?.href || "/");
+
+	return (
+		<div className="flex h-full grow items-center justify-center">
+			<div className="flex w-[32rem] flex-col gap-4 overflow-hidden rounded-xl border border-tertiary-300 bg-tertiary-50 p-8">
+				<span className="text-xl">
+					<VSekaiMark className="inline size-5" /> Admin Access Status
+				</span>
+				<p className="opacity-75">
+					Status: {" "}
+					<span className="font-medium">{adminStatus?.status?.is_admin}</span>
+					You have admin panel access.
+				</p>
+				<div className="flex gap-2">
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/lib/uro/controllers/admin.ex
+++ b/lib/uro/controllers/admin.ex
@@ -1,0 +1,36 @@
+defmodule Uro.AdminController do
+  use Uro, :controller
+
+  alias OpenApiSpex.Schema
+
+  tags(["admin"])
+
+  operation(:status,
+    operation_id: "getAdminStatus",
+    summary: "Get Admin status",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{
+          type: :object,
+          properties: %{
+            status: %Schema{
+              type: :object,
+              properties: %{
+                is_admin: %Schema{
+                  type: :string,
+                  enum: ["true", "false"]
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  )
+
+  def status(conn, _params) do
+    json(conn, %{status: %{is_admin: "true"}})
+  end
+end

--- a/lib/uro/controllers/avatar.ex
+++ b/lib/uro/controllers/avatar.ex
@@ -1,7 +1,22 @@
 defmodule Uro.AvatarController do
   use Uro, :controller
 
+  alias OpenApiSpex.Schema
   alias Uro.UserContent
+
+  tags(["avatars"])
+
+  operation(:index,
+    operation_id: "listAvatars",
+    summary: "List Avatars",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
 
   def index(conn, _params) do
     avatars = UserContent.list_public_avatars()
@@ -17,6 +32,46 @@ defmodule Uro.AvatarController do
       }
     })
   end
+
+  operation(:indexUploads,
+    operation_id: "listAvatarsUploads",
+    summary: "List Avatars uploaded by logged in user",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def indexUploads(conn, _params) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+    avatars = UserContent.list_avatars_uploaded_by(user)
+
+    conn
+    |> put_status(200)
+    |> json(%{
+      data: %{
+        avatars:
+          Uro.Helpers.UserContentHelper.get_api_user_content_list(avatars, %{
+            merge_uploader_id: true
+          })
+      }
+    })
+  end
+
+  operation(:show,
+    operation_id: "getAvatar",
+    summary: "Get Avatar",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
 
   def show(conn, %{"id" => id}) do
     id
@@ -39,6 +94,176 @@ defmodule Uro.AvatarController do
         put_status(
           conn,
           400
+        )
+    end
+  end
+
+  operation(:showUpload,
+    operation_id: "getAvatarUpload",
+    summary: "Get uploaded Avatar",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def showUpload(conn, %{"id" => id}) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+
+    case UserContent.get_avatar_uploaded_by_user!(id, user) do
+      %Uro.UserContent.Avatar{} = avatar ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: %{
+            avatar:
+              Uro.Helpers.UserContentHelper.get_api_user_content(
+                avatar,
+                %{merge_uploader_id: true, merge_is_public: true}
+              )
+          }
+        })
+
+      _ ->
+        put_status(
+          conn,
+          400
+        )
+    end
+  end
+
+  operation(:create,
+    operation_id: "createAvatar",
+    summary: "Create Avatar",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def create(conn, %{"avatar" => avatar_params}) do
+    case UserContent.create_avatar(
+           Uro.Helpers.UserContentHelper.get_correct_user_content_params(
+             conn,
+             avatar_params,
+             "user_content_data",
+             "user_content_preview"
+           )
+         ) do
+      {:ok, avatar} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: %{
+            id: to_string(avatar.id),
+            avatar:
+              Uro.Helpers.UserContentHelper.get_api_user_content(
+                avatar,
+                %{merge_uploader_id: true}
+              )
+          }
+        })
+
+      {:error, %Ecto.Changeset{changes: changes, errors: errors} = _changeset} ->
+        conn
+        |> put_status(500)
+        |> (fn conn ->
+              if Mix.env() == "dev" do
+                json(
+                  conn,
+                  %{changes: changes, errors: errors}
+                )
+              end
+            end).()
+    end
+  end
+
+  operation(:update,
+    operation_id: "updateAvatar",
+    summary: "Update Avatar",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def update(conn, %{"id" => id, "avatar" => avatar_params}) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+    avatar = UserContent.get_avatar_uploaded_by_user!(id, user)
+
+    case UserContent.update_avatar(avatar, avatar_params) do
+      {:ok, avatar} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: %{
+            id: to_string(avatar.id),
+            avatar:
+              Uro.Helpers.UserContentHelper.get_api_user_content(
+                avatar,
+                %{merge_uploader_id: true}
+              )
+          }
+        })
+
+      {:error, %Ecto.Changeset{changes: changes, errors: errors} = _changeset} ->
+        conn
+        |> put_status(500)
+        |> (fn conn ->
+              if Mix.env() == "dev" do
+                json(
+                  conn,
+                  %{changes: changes, errors: errors}
+                )
+              end
+            end).()
+    end
+  end
+
+  operation(:delete,
+    operation_id: "deleteAvatar",
+    summary: "Delete Avatar",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+
+    case UserContent.get_avatar_uploaded_by_user!(id, user) do
+      %Uro.UserContent.Avatar{} = avatar ->
+        case UserContent.delete_avatar(avatar) do
+          {:ok, _avatar} ->
+            put_status(
+              conn,
+              200
+            )
+
+          {:error, %Ecto.Changeset{}} ->
+            put_status(
+              conn,
+              500
+            )
+        end
+
+      _ ->
+        put_status(
+          conn,
+          200
         )
     end
   end

--- a/lib/uro/controllers/identity_proof_controller.ex
+++ b/lib/uro/controllers/identity_proof_controller.ex
@@ -1,6 +1,8 @@
 defmodule Uro.IdentityProofController do
   use Uro, :controller
 
+  alias Uro.Error
+
   @spec create(Conn.t(), map()) :: Conn.t()
   def create(conn, %{"identity_proof" => identity_proof_params}) do
     if !Map.has_key?(identity_proof_params, "user_to") do

--- a/lib/uro/controllers/map.ex
+++ b/lib/uro/controllers/map.ex
@@ -6,8 +6,48 @@ defmodule Uro.MapController do
 
   tags(["maps"])
 
+  operation(:index,
+    operation_id: "listMaps",
+    summary: "List Maps",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
   def index(conn, _params) do
     maps = UserContent.list_public_maps()
+
+    conn
+    |> put_status(200)
+    |> json(%{
+      data: %{
+        maps:
+          Uro.Helpers.UserContentHelper.get_api_user_content_list(maps, %{
+            merge_uploader_id: true
+          })
+      }
+    })
+  end
+
+  operation(:indexUploads,
+    operation_id: "listMapsUploads",
+    summary: "List Maps uploaded by logged in user",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def indexUploads(conn, _params) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+    maps = UserContent.list_maps_uploaded_by(user)
 
     conn
     |> put_status(200)
@@ -54,6 +94,176 @@ defmodule Uro.MapController do
         put_status(
           conn,
           400
+        )
+    end
+  end
+
+  operation(:showUpload,
+    operation_id: "getMapUpload",
+    summary: "Get uploaded Map",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def showUpload(conn, %{"id" => id}) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+
+    case UserContent.get_map_uploaded_by_user!(id, user) do
+      %Uro.UserContent.Map{} = map ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: %{
+            map:
+              Uro.Helpers.UserContentHelper.get_api_user_content(
+                map,
+                %{merge_uploader_id: true, merge_is_public: true}
+              )
+          }
+        })
+
+      _ ->
+        put_status(
+          conn,
+          400
+        )
+    end
+  end
+
+  operation(:create,
+    operation_id: "createMap",
+    summary: "Create Map",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def create(conn, %{"map" => map_params}) do
+    case UserContent.create_map(
+           Uro.Helpers.UserContentHelper.get_correct_user_content_params(
+             conn,
+             map_params,
+             "user_content_data",
+             "user_content_preview"
+           )
+         ) do
+      {:ok, map} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: %{
+            id: to_string(map.id),
+            map:
+              Uro.Helpers.UserContentHelper.get_api_user_content(
+                map,
+                %{merge_uploader_id: true}
+              )
+          }
+        })
+
+      {:error, %Ecto.Changeset{changes: changes, errors: errors} = _changeset} ->
+        conn
+        |> put_status(500)
+        |> (fn conn ->
+              if Mix.env() == "dev" do
+                json(
+                  conn,
+                  %{changes: changes, errors: errors}
+                )
+              end
+            end).()
+    end
+  end
+
+  operation(:update,
+    operation_id: "updateMap",
+    summary: "Update Map",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def update(conn, %{"id" => id, "map" => map_params}) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+    map = UserContent.get_map_uploaded_by_user!(id, user)
+
+    case UserContent.update_map(map, map_params) do
+      {:ok, map} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: %{
+            id: to_string(map.id),
+            map:
+              Uro.Helpers.UserContentHelper.get_api_user_content(
+                map,
+                %{merge_uploader_id: true}
+              )
+          }
+        })
+
+      {:error, %Ecto.Changeset{changes: changes, errors: errors} = _changeset} ->
+        conn
+        |> put_status(500)
+        |> (fn conn ->
+              if Mix.env() == "dev" do
+                json(
+                  conn,
+                  %{changes: changes, errors: errors}
+                )
+              end
+            end).()
+    end
+  end
+
+  operation(:delete,
+    operation_id: "deleteMap",
+    summary: "Delete Map",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        %Schema{}
+      }
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = Uro.Helpers.Auth.get_current_user(conn)
+
+    case UserContent.get_map_uploaded_by_user!(id, user) do
+      %Uro.UserContent.Map{} = map ->
+        case UserContent.delete_map(map) do
+          {:ok, _map} ->
+            put_status(
+              conn,
+              200
+            )
+
+          {:error, %Ecto.Changeset{}} ->
+            put_status(
+              conn,
+              500
+            )
+        end
+
+      _ ->
+        put_status(
+          conn,
+          200
         )
     end
   end

--- a/lib/uro/controllers/shard.ex
+++ b/lib/uro/controllers/shard.ex
@@ -56,10 +56,11 @@ defmodule Uro.ShardController do
 
   def index(conn, _params) do
     shards = VSekai.list_fresh_shards()
+    shards_json = Enum.map(shards, fn x -> Shard.to_json_schema(x) end)
 
     conn
     |> put_status(200)
-    |> json(shards)
+    |> json(%{data: %{shards: shards_json}})
   end
 
   operation(:create,
@@ -101,7 +102,7 @@ defmodule Uro.ShardController do
       {:ok, shard} ->
         conn
         |> put_status(200)
-        |> json(%{id: shard.id})
+        |> json(%{data: %{id: to_string(shard.id)}})
 
       {:error, %Ecto.Changeset{}} ->
         json_error(conn)
@@ -136,7 +137,7 @@ defmodule Uro.ShardController do
         {:ok, shard} ->
           conn
           |> put_status(200)
-          |> json(shard)
+          |> json(%{data: %{id: to_string(shard.id)}})
 
         {:error, %Ecto.Changeset{}} ->
           json_error(conn)
@@ -175,6 +176,7 @@ defmodule Uro.ShardController do
       Uro.VSekai.Shard
       |> Repo.get!(id)
       |> Repo.preload(:user)
+      |> Repo.preload(user: [:user_privilege_ruleset])
 
     if can_connection_modify_shard(conn, shard) do
       case VSekai.delete_shard(shard) do

--- a/lib/uro/controllers/user.ex
+++ b/lib/uro/controllers/user.ex
@@ -10,6 +10,7 @@ defmodule Uro.UserController do
   alias OpenApiSpex.Schema
   alias Uro.Accounts
   alias Uro.Accounts.User
+  alias Uro.Accounts.UserPrivilegeRuleset
   alias Uro.Repo
   alias Uro.Session
   alias Uro.Turnstile
@@ -49,6 +50,46 @@ defmodule Uro.UserController do
       conn
       |> put_status(:ok)
       |> json(User.to_json_schema(user, conn))
+    end
+  end
+
+  operation(:showCurrent,
+    operation_id: "getUserCurrent",
+    summary: "Get Current User",
+    parameters: [
+      user_id: [
+        in: :path,
+        schema: User.loose_key_json_schema()
+      ]
+    ],
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        User.json_schema()
+      },
+      not_found: {
+        "User not found",
+        "application/json",
+        error_json_schema()
+      }
+    ]
+  )
+
+  def showCurrent(conn, _params) do
+    with {:ok, user} <- user_from_key(conn, "me") do
+      ruleset = UserPrivilegeRuleset.to_json_schema(user.user_privilege_ruleset)
+
+      conn
+      |> put_status(:ok)
+      |> json(%{
+        data: %{
+          access_token: conn.assigns[:access_token],
+          renewal_token: conn.assigns[:access_token],
+          user: User.to_json_schema(user, conn),
+          user_privilege_ruleset: ruleset
+        }
+      })
     end
   end
 
@@ -116,6 +157,61 @@ defmodule Uro.UserController do
     Repo.transaction(fn ->
       with {:ok, _} <- Turnstile.verify_captcha(conn),
            {:ok, user} <- Accounts.create(params),
+           :ok <- Accounts.send_confirmation_email(user),
+           conn <- Pow.Plug.create(conn, user) do
+        {user, conn}
+      else
+        any ->
+          Repo.rollback(any)
+      end
+    end)
+    |> case do
+      {:ok, {_, conn}} ->
+        {:ok, session} = current_session(conn)
+
+        json(
+          conn,
+          Session.to_json_schema(session)
+        )
+
+      {:error, conn} ->
+        conn
+    end
+  end
+
+  operation(:createClient,
+    operation_id: "signupClient",
+    summary: "Create an Account from Game client request",
+    responses: [
+      ok: {
+        "",
+        "application/json",
+        Session.json_schema()
+      },
+      unprocessable_entity: {
+        "",
+        "application/json",
+        error_json_schema()
+      }
+    ]
+  )
+
+  def createClient(conn, %{"user" => user_params, "apiKey" => api_key}) do
+    create_params = %{
+      "username" => Map.get(user_params, "username"),
+      "display_name" => Map.get(user_params, "username"),
+      "email" => Map.get(user_params, "email"),
+      "password" => Map.get(user_params, "password")
+    }
+
+    Repo.transaction(fn ->
+      with :ok <-
+             (fn ->
+                if api_key == System.get_env("SIGNUP_API_KEY") do
+                  :ok
+                end
+              end).(),
+           {:ok, user} <- Accounts.create(create_params),
            :ok <- Accounts.send_confirmation_email(user),
            conn <- Pow.Plug.create(conn, user) do
         {user, conn}

--- a/lib/uro/endpoint.ex
+++ b/lib/uro/endpoint.ex
@@ -9,6 +9,12 @@ defmodule Uro.Endpoint do
     plug(Phoenix.CodeReloader)
   end
 
+  plug(Plug.Static,
+    at: "/uploads",
+    from: Path.expand("./uploads"),
+    gzip: false
+  )
+
   plug(Plug.RequestId, assign_as: :request_id)
   plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
 

--- a/lib/uro/helpers/admin.ex
+++ b/lib/uro/helpers/admin.ex
@@ -1,0 +1,13 @@
+defmodule Uro.Helpers.Admin do
+  @moduledoc """
+  Admin helper functions, automatically imported by controllers.
+  """
+
+  alias Uro.Accounts.User
+  alias Uro.Helpers.Auth
+
+  def is_session_admin?(conn) do
+    user = Auth.get_current_user(conn)
+    User.admin?(user)
+  end
+end

--- a/lib/uro/helpers/user.ex
+++ b/lib/uro/helpers/user.ex
@@ -87,4 +87,14 @@ defmodule Uro.Helpers.User do
       message: "must be yourself"
     )
   end
+
+  def is_session_user?(conn) do
+    user = user_from_key(conn, "me")
+
+    case user do
+      {:ok, _result} -> true
+      {:error, _reason} -> false
+      _ -> false
+    end
+  end
 end

--- a/lib/uro/plug/authentication.ex
+++ b/lib/uro/plug/authentication.ex
@@ -122,6 +122,9 @@ defmodule Uro.Plug.Authentication do
       ["Bearer" <> " " <> access_token | _] ->
         {:ok, access_token}
 
+      [access_token | _] ->
+        {:ok, access_token}
+
       _ ->
         case conn.cookies do
           %{"session" => access_token} when is_binary(access_token) ->

--- a/lib/uro/plug/choose_auth.ex
+++ b/lib/uro/plug/choose_auth.ex
@@ -1,0 +1,32 @@
+defmodule Uro.Plug.ChooseAuth do
+  import Plug.Conn
+
+  def init(default), do: default
+
+  def call(conn, opts) do
+    if has_authorization_header?(conn) do
+      # Game client
+      token = get_req_header(conn, "authorization")
+
+      case token do
+        [] ->
+          conn
+
+        [auth_header] ->
+          assign(conn, :signed_access_token, token)
+      end
+
+      Uro.Plug.RequireUser.call(conn, Uro.Plug.RequireUser.init(opts))
+    else
+      opts = Keyword.merge(opts, error_handler: Uro.FallbackController)
+      Pow.Plug.RequireAuthenticated.call(conn, Pow.Plug.RequireAuthenticated.init(opts))
+    end
+  end
+
+  defp has_authorization_header?(conn) do
+    case get_req_header(conn, "authorization") do
+      [] -> false
+      [_ | _] -> true
+    end
+  end
+end

--- a/lib/uro/plug/require_user.ex
+++ b/lib/uro/plug/require_user.ex
@@ -1,0 +1,25 @@
+defmodule Uro.Plug.RequireUser do
+  import Plug.Conn
+
+  @doc false
+  def init(options), do: options
+
+  @doc false
+  @spec call(Conn.t(), any()) :: Conn.t()
+  def call(conn, _opts) do
+    conn
+    |> Uro.Helpers.User.is_session_user?()
+    |> maybe_halt(conn)
+  end
+
+  @doc false
+  defp maybe_halt(true, conn), do: conn
+
+  @doc false
+  defp maybe_halt(false, conn) do
+    conn
+    |> put_status(403)
+    |> send_resp(403, "Unauthorized 403")
+    |> halt()
+  end
+end

--- a/lib/uro/router.ex
+++ b/lib/uro/router.ex
@@ -28,6 +28,27 @@ defmodule Uro.Router do
     plug(Pow.Plug.RequireAuthenticated, error_handler: Uro.FallbackController)
   end
 
+  pipeline :authenticated_admin do
+    plug(Pow.Plug.RequireAuthenticated, error_handler: Uro.FallbackController)
+    plug(Uro.Plug.RequireAdmin)
+  end
+
+  pipeline :authenticated_user do
+    plug(Uro.Plug.ChooseAuth)
+  end
+
+  pipeline :dashboard_avatars do
+    plug(Uro.Plug.RequireAvatarUploadPermission)
+  end
+
+  pipeline :dashboard_maps do
+    plug(Uro.Plug.RequireMapUploadPermission)
+  end
+
+  pipeline :dashboard_props do
+    plug(Uro.Plug.RequirePropUploadPermission)
+  end
+
   if Mix.env() == :dev do
     pipeline :browser do
       plug(:accepts, ["html"])
@@ -51,8 +72,30 @@ defmodule Uro.Router do
   get("/openapi", OpenApiSpex.Plug.RenderSpec, [])
   get("/docs", Uro.OpenAPI.Viewer, [])
 
+  #### Used by game client only ####
+  # TODO: merge into other routes
+
+  # User signup using apiKey client secret
+  scope "/registration" do
+    post "/", Uro.UserController, :createClient
+  end
+
+  scope "/profile" do
+    pipe_through([:authenticated_user])
+    get("/", Uro.UserController, :showCurrent)
+  end
+
+  ##################################
+
   scope "/session" do
-    pipe_through([:authenticated])
+    # TODO: used by game client only, move to '/login' route
+    post("/", Uro.AuthenticationController, :loginClient)
+
+    scope "/renew" do
+      post("/", Uro.AuthenticationController, :renew)
+    end
+
+    pipe_through([:authenticated_user])
 
     get("/", Uro.AuthenticationController, :get_current_session)
     delete("/", Uro.AuthenticationController, :logout)
@@ -67,10 +110,16 @@ defmodule Uro.Router do
     end
   end
 
-  # resources("/avatars", UserContent.AvatarController, only: [:show])
-  resources("/maps", Uro.MapController, only: [:show])
+  resources("/avatars", Uro.AvatarController, only: [:index, :show])
+  resources("/maps", Uro.MapController, only: [:index, :show])
 
   resources("/shards", Uro.ShardController, only: [:index, :create, :update, :delete])
+
+  scope "/admin" do
+    pipe_through([:authenticated_admin])
+
+    get("/", Uro.AdminController, :status)
+  end
 
   scope "/users" do
     post "/", Uro.UserController, :create
@@ -98,5 +147,37 @@ defmodule Uro.Router do
         )
       end
     end
+  end
+
+  scope "/dashboard" do
+    pipe_through([:authenticated_user])
+
+    get("/", Uro.AuthenticationController, :get_current_session)
+    delete("/", Uro.AuthenticationController, :logout)
+
+    scope "/avatars" do
+      pipe_through([:dashboard_avatars])
+
+      get "/", Uro.AvatarController, :indexUploads
+      get "/:id", Uro.AvatarController, :showUpload
+      post "/", Uro.AvatarController, :create
+      put "/:id", Uro.AvatarController, :update
+      delete "/:id", Uro.AvatarController, :delete
+    end
+
+    scope "/maps" do
+      pipe_through([:dashboard_maps])
+
+      get "/", Uro.MapController, :indexUploads
+      get "/:id", Uro.MapController, :showUpload
+      post "/", Uro.MapController, :create
+      put "/:id", Uro.MapController, :update
+      delete "/:id", Uro.MapController, :delete
+    end
+
+    # scope "/props" do
+    #  pipe_through([:dashboard_props])
+    #  get "/", Uro.PropController, :index
+    # end
   end
 end

--- a/lib/uro/v_sekai.ex
+++ b/lib/uro/v_sekai.ex
@@ -77,8 +77,11 @@ defmodule Uro.VSekai do
 
   """
   def create_shard(attrs \\ %{}) do
+    shard_data = Map.get(attrs, "shard", %{})
+    flattened_attrs = Map.merge(Map.drop(attrs, ["shard"]), shard_data)
+
     %Shard{}
-    |> Shard.changeset(attrs)
+    |> Shard.changeset(flattened_attrs)
     |> Repo.insert()
   end
 

--- a/lib/uro/v_sekai/shard.ex
+++ b/lib/uro/v_sekai/shard.ex
@@ -64,6 +64,16 @@ defmodule Uro.VSekai.Shard do
 
   def json_schema, do: @json_schema
 
+  def to_json_schema(%__MODULE__{} = shard) do
+    %{
+      user: User.to_limited_json_schema(shard.user),
+      address: to_string(shard.address),
+      port: shard.port,
+      map: to_string(shard.map),
+      name: to_string(shard.name)
+    }
+  end
+
   @doc false
   def changeset(shard, attrs) do
     shard

--- a/priv/repo/test_seeds.exs
+++ b/priv/repo/test_seeds.exs
@@ -34,10 +34,11 @@ Repo.transaction(fn ->
           password_confirmation: "userpassword",
           email_confirmed_at: current_time
         })
+        |> User.confirm_email_changeset()
         |> Repo.insert!()
       user ->
         user
-        |> User.admin_changeset(%{email_confirmed_at: current_time})
+        |> User.confirm_email_changeset()
         |> Repo.update!()
     end
 
@@ -67,10 +68,11 @@ Repo.transaction(fn ->
           password_confirmation: "adminpassword",
           email_confirmed_at: current_time
         })
+        |> User.confirm_email_changeset()
         |> Repo.insert!()
       user ->
         user
-        |> User.admin_changeset(%{email_confirmed_at: current_time})
+        |> User.confirm_email_changeset()
         |> Repo.update!()
     end
 

--- a/priv/repo/test_user_content.exs
+++ b/priv/repo/test_user_content.exs
@@ -1,0 +1,50 @@
+# Script for populating the database. You can run it as:
+#
+#     mix run priv/repo/test_user_content.exs
+#
+# Script must be run from repository root
+
+alias Uro.UserContent
+alias Uro.Repo
+
+# Create upload database entries with user "adminuser"
+
+user = Repo.get_by(Uro.Accounts.User, username: "adminuser")
+uploader = user.id
+
+process_file = fn (path, content_type) -> 
+  file = %Plug.Upload{
+    path: path,
+    filename: Path.basename(path),
+    content_type: content_type
+  }
+  file
+end
+
+
+avatar1 = UserContent.create_avatar(%{
+      name: "TestAvatar1",
+      description: "First test avatar",
+      user_content_data: process_file.("priv/repo/test_content/test_avatar1.scn", "application/octet-stream"),
+      uploader_id: uploader,
+      user_content_preview: process_file.("priv/repo/test_content/test_image.jpg", "image/jpeg"),
+      is_public: true
+})
+
+scene1 = UserContent.create_map(%{
+      name: "TestScene1",
+      description: "First test scene",
+      user_content_data: process_file.("priv/repo/test_content/test_scene1.scn", "application/octet-stream"),
+      uploader_id: uploader,
+      user_content_preview: process_file.("priv/repo/test_content/test_image.jpg", "image/jpeg"),
+      is_public: true
+})
+
+scene2 = UserContent.create_map(%{
+      name: "TestScene2",
+      description: "Second test scene",
+      user_content_data: process_file.("priv/repo/test_content/test_scene2.scn", "application/octet-stream"),
+      uploader_id: uploader,
+      user_content_preview: process_file.("priv/repo/test_content/test_image.jpg", "image/jpeg"),
+      is_public: true
+})


### PR DESCRIPTION
#103
### Additions
- Add temporary Mailer config (in-memory email storage) for production. This must be replaced with an email service adapter in final server.
- Serve user content at `/uploads` with Waffle and Caddyfile
- Require `authenticated_user` to access certain endpoints. Since game client and website share some endpoints, a `ChooseAuth` plug was added to fallback to `Cookie` authentication if `Authorization` header is missing.
- Add avatar/maps `/dashboard` endpoints
- Add `/admin` api endpoint and control panel page stub
- Add `/profile` `/session` `/registration` game client endpoints
- Add `/session/renew` dummy endpoint to refresh access tokens for game client compatibility
- Completed `/shards` endpoints implementation
- Add `SIGNUP_API_KEY` key to authenticate game client signup requests
- Add script `priv/repo/test_user_content.exs` to populate database with test user content

### Fixes
- Disable `cache_static_manifest` (no file is served from `priv/static`)
- Fix missing alias in `lib/uro/controllers/identity_proof_controller.ex`
- Add missing function `is_session_admin?/1`
- Fix `Uro.Plug.Authentication` authentication. Client `Authorization` token was not recognized because it was sent without `Bearer ` prefix
- Fix `priv/repo/test_seeds.exs` not confirming email of generated users

Endpoints were tested with `curl`, further testing is needed

**Missing features:**
- Define openapi avatar/maps query specs