### PR TITLE
Fix environment variables embedded in builds

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,8 +1,8 @@
-NEXT_PUBLIC_ORIGIN=https://vsekai.local
+NEXTJS_ORIGIN=https://vsekai.local
 
 API_ORIGIN=http://uro:4000
-NEXT_PUBLIC_API_ORIGIN=https://vsekai.local/api/v1
+NEXTJS_API_ORIGIN=https://vsekai.local/api/v1
 
 # Cloudflare Turnstile captcha
 # Currently set to "Always pass" testing key.
-NEXT_PUBLIC_TURNSTILE_SITEKEY=1x00000000000000000000AA
+NEXTJS_TURNSTILE_SITEKEY=1x00000000000000000000AA

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
 import { client } from "@hey-api/client-fetch";
 import { randomInt } from "@ariesclark/extensions";
 
-import { apiOrigin, development } from "./environment";
+import { development, getServerEnv } from "./environment";
 
 const config = client.getConfig();
 
@@ -21,7 +21,7 @@ const relevantHeaders = new Set([
 	"x-forwarded-proto"
 ]);
 
-config.baseUrl = apiOrigin;
+config.baseUrl = getServerEnv()?.apiOrigin || "";
 config.fetch = async (request: Request) => {
 	if (development)
 		// Simulate network latency in development, encouraging optimistic updates & proper loading states.

--- a/frontend/src/app/api/env/route.js
+++ b/frontend/src/app/api/env/route.js
@@ -1,0 +1,15 @@
+// Expose some server env variables to client as API
+export const dynamic = 'force-dynamic';
+
+export async function GET(request) {
+  const responseBody = {
+    origin: process.env.NEXTJS_ORIGIN,
+    apiOrigin: process.env.NEXTJS_API_ORIGIN,
+    turnstileSiteKey: process.env.NEXTJS_TURNSTILE_SITEKEY,
+  };
+
+  return new Response(JSON.stringify(responseBody), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/frontend/src/components/captcha.tsx
+++ b/frontend/src/components/captcha.tsx
@@ -13,7 +13,7 @@ import {
 } from "react";
 import { twMerge } from "tailwind-merge";
 
-import { turnstileSiteKey } from "~/environment";
+import { getServerEnv } from "~/environment";
 import { MutationFormContext } from "~/hooks/form";
 import { useTheme } from "~/hooks/theme";
 
@@ -25,6 +25,7 @@ const CaptchaContent: FC<
 	CaptchaProps & { promise: Promise<Turnstile.Turnstile> }
 > = ({ onChange: _onChange, promise }) => {
 	const turnstile = use(promise);
+	const turnstileSiteKey = getServerEnv()?.turnstileSiteKey || "";
 
 	const { theme } = useTheme();
 	const reference = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/link.tsx
+++ b/frontend/src/components/link.tsx
@@ -9,13 +9,15 @@ import {
 } from "react";
 
 import { dataAttribute } from "~/element";
-import { firstPartyOrigins, origin } from "~/environment";
+import { getFirstPartyOrigins, getServerEnv } from "~/environment";
 
 export const Link = forwardRef<
 	ComponentRef<typeof LinkPrimitive>,
 	ComponentProps<typeof LinkPrimitive>
 >(({ href: _href, children, className, ...props }, reference) => {
 	const { href, external } = useMemo(() => {
+		const origin = getServerEnv()?.origin || "";
+		const firstPartyOrigins = getFirstPartyOrigins();
 		const url = new URL(_href.toString(), origin);
 		const href =
 			url.origin === origin ? url.href.replace(origin, "") : url.href;

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -5,21 +5,6 @@ function environment<T>(value: unknown, name: string): T {
 
 export const development = process.env.NODE_ENV === "development";
 
-export const origin = environment<string>(
-	process.env.NEXT_PUBLIC_ORIGIN,
-	"NEXT_PUBLIC_ORIGIN"
-);
-
-export const apiOrigin = environment<string>(
-	process.env.API_ORIGIN || process.env.NEXT_PUBLIC_API_ORIGIN,
-	"API_ORIGIN and or NEXT_PUBLIC_API_ORIGIN"
-);
-
-export const turnstileSiteKey = environment<string>(
-	process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY,
-	"NEXT_PUBLIC_TURNSTILE_SITEKEY"
-);
-
 if (development) {
 	process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
 }
@@ -30,8 +15,85 @@ export const urls = {
 	twitter: "https://twitter.com/vsekaiofficial"
 };
 
+// Runtime fetch from API
+interface serverEnvType {
+	origin: string;
+	apiOrigin: string;
+	turnstileSiteKey: string
+};
+
+let envCache: serverEnvType | null = null;
+
+export const getServerEnv = (): serverEnvType | null => {
+  if (envCache) {
+    // console.log("Using cached env:", envCache);
+    return envCache;
+  }
+
+  // Server-side
+  if (typeof window === "undefined") {
+    const serverEnv = {
+        origin: environment<string>(
+            process.env.NEXTJS_ORIGIN,
+            "NEXTJS_ORIGIN"
+        ),
+        apiOrigin: environment<string>( // API_ORIGIN is only used server-side
+            process.env.API_ORIGIN || process.env.NEXTJS_API_ORIGIN,
+            "API_ORIGIN and or NEXTJS_API_ORIGIN"
+        ),
+        turnstileSiteKey: environment<string>(
+            process.env.NEXTJS_TURNSTILE_SITEKEY,
+            "NEXTJS_TURNSTILE_SITEKEY"
+        )
+    };
+
+    envCache = serverEnv;
+    // console.log("Fetched environment on server side.");
+    return serverEnv;
+  }
+
+  // Client-side
+  try {
+    const xhr = new XMLHttpRequest();
+    let timeout = setTimeout(function () {
+        xhr.abort();
+        console.error("Request timed out");
+    }, 5000);
+	  
+    xhr.open("GET", "/api/env", false); // Synchronous XMLHttpRequest
+    xhr.send();
+    clearTimeout(timeout);
+
+    if (xhr.status === 200) {
+      envCache = JSON.parse(xhr.responseText);
+      // console.log("Fetched serverEnv:", envCache);
+      return envCache;
+    } else {
+      console.error(`Failed to fetch server environment: ${xhr.status}`);
+    }
+  } catch (error) {
+    console.error("Error fetching server environment:", String(error));
+  }
+
+  return null;
+};
+
 /**
  * A set of first-party origins, these are given special treatment in the
  * application, such as in OAuth2 redirection & opening links in a new tab.
+ * Add to set below if required.
  */
-export const firstPartyOrigins = new Set([origin]);
+const firstPartyOrigins: Set<string> = new Set([]);
+
+export const getFirstPartyOrigins = (): Set<string> => {
+  const appOrigin = getServerEnv()?.origin;
+  let origins = firstPartyOrigins;
+
+  // Ensure firstPartyOrigins includes the fetched origin
+  if (appOrigin) {
+    origins.add(appOrigin);
+  }
+
+  // console.log("First-party origins:", [...origins]);
+  return origins;
+};

--- a/frontend/src/hooks/location.ts
+++ b/frontend/src/hooks/location.ts
@@ -1,6 +1,6 @@
 import { usePathname, useSearchParams } from "next/navigation";
 
-import { origin } from "~/environment";
+import { getServerEnv } from "~/environment";
 
 type Location = URL & { current: string };
 
@@ -10,6 +10,7 @@ type Location = URL & { current: string };
 export function useLocation(): Location {
 	const pathname = usePathname();
 	const searchParameters = useSearchParams();
+	const origin = getServerEnv()?.origin || "";
 
 	const current = `${pathname}${searchParameters.size > 0 ? `?${searchParameters.toString()}` : ""}`;
 	return Object.assign(new URL(current, origin), { current });

--- a/frontend/src/hooks/return-intent/common.ts
+++ b/frontend/src/hooks/return-intent/common.ts
@@ -1,12 +1,15 @@
 import { redirect } from "next/navigation";
 
-import { firstPartyOrigins, origin } from "~/environment";
+import { getFirstPartyOrigins, getServerEnv } from "~/environment";
 
 /**
  * Redirects the user to the return intent, if it is a first-party origin, otherwise to the home page.
  * @see https://www.fastly.com/blog/open-redirects-real-world-abuse-and-recommendations/
  */
 export function restoreReturnIntent(ri: string) {
+	const origin = getServerEnv()?.origin || "";
+	const firstPartyOrigins = getFirstPartyOrigins();
+
 	const returnIntent = new URL(ri, origin);
 
 	if (!firstPartyOrigins.has(returnIntent.origin)) return redirect("/");

--- a/frontend/src/hooks/return-intent/index.ts
+++ b/frontend/src/hooks/return-intent/index.ts
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 
-import { firstPartyOrigins, origin } from "~/environment";
+import { getFirstPartyOrigins, getServerEnv } from "~/environment";
 
 import { useLocation } from "../location";
 
 function minimizeHref(href: URL | string) {
+	const origin = getServerEnv()?.origin || "";
 	const url = new URL(href.toString(), origin);
 	return url.origin === origin ? url.href.replace(origin, "") : url.href;
 }
@@ -17,6 +18,9 @@ export function useReturnIntent() {
 	const _returnIntent = searchParams.get("ri");
 
 	return useMemo(() => {
+		const origin = getServerEnv()?.origin || "";
+		const firstPartyOrigins = getFirstPartyOrigins();
+
 		let returnIntent = _returnIntent ? new URL(_returnIntent, origin) : null;
 		if (returnIntent && !firstPartyOrigins.has(returnIntent.origin))
 			returnIntent = null;


### PR DESCRIPTION
`NEXT_PUBLIC_` environment variables are embedded at build time in Docker image, breaking build once assumption. The solution is to create an API endpoint to fetch server environment variables at runtime.

A bug in login redirect prevents proper testing of React hooks, so as a temporary workaround I used synchronous HTTP request to fetch environment.