### PR TITLE
Fix missing /props GET endpoint

### DIFF
--- a/lib/uro/router.ex
+++ b/lib/uro/router.ex
@@ -116,6 +116,7 @@ defmodule Uro.Router do
 
   resources("/avatars", Uro.AvatarController, only: [:index, :show])
   resources("/maps", Uro.MapController, only: [:index, :show])
+  resources("/props", Uro.PropController, only: [:index, :show])
 
   resources("/shards", Uro.ShardController, only: [:index, :create, :update, :delete])
 


### PR DESCRIPTION
These endpoints are required to list props and get a single prop