### PR TITLE
Add build-time dependency to nextjs service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,9 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      additional_contexts:
+         # Enforce build-time dependency (openapi.json generation)
+         uro: "service:uro"
     env_file:
       - frontend/.env
     # healthcheck:


### PR DESCRIPTION
Docker Compose v2 uses [parallel building](https://docs.docker.com/compose/how-tos/dependent-images/#use-another-services-image-as-the-base-image) so `docker compose up` always failed because uro image was not built yet.
I added a build time dependency with `additional_contexts`.