### PR TITLE
Fix /registration API endpoint error

### DIFF
--- a/lib/uro/accounts/session.ex
+++ b/lib/uro/accounts/session.ex
@@ -49,4 +49,51 @@ defmodule Uro.Session do
       expires_in: session.expires_in
     }
   end
+
+  # Legacy API interface for game client only.
+  # TODO: Merge with above Schema in future API revision.
+  @json_game_client_schema %Schema{
+    title: "GameSession",
+    description:
+      "A game client user session, containing access/renewal token and user information.",
+    type: :object,
+    required: [
+      :user,
+      :access_token,
+      :renewal_token,
+      :expires_in
+    ],
+    properties: %{
+      user: User.sensitive_json_schema(),
+      access_token: %Schema{
+        description:
+          "The access token, used for authenticating requests. Sent as a cookie `cookie: session=<access_token>`, or alternatively, in the `authorization` header, like so `authorization: Bearer <access_token>`.",
+        type: :string
+      },
+      renewal_token: %Schema{
+        description: "The renewal token, used for refreshing access token. Not implemented.",
+        type: :string
+      },
+      expires_in: %Schema{
+        type: :integer,
+        description:
+          "The number of milliseconds until `access_token` expires. You'll usually be automatically assigned a new `access_token` via the `set-cookie` header before this time."
+      }
+    }
+  }
+
+  def json_game_client_schema, do: @json_game_client_schema
+
+  # TODO: Implement token renewal feature.
+  # Currently we return 'access_token' as renewal token to match client interface.
+  def to_json_game_client_schema(%__MODULE__{} = session) do
+    %{
+      data: %{
+        user: User.to_sensitive_json_schema(session.user),
+        access_token: session.access_token,
+        renewal_token: session.access_token,
+        expires_in: session.expires_in
+      }
+    }
+  end
 end

--- a/lib/uro/controllers/user.ex
+++ b/lib/uro/controllers/user.ex
@@ -186,7 +186,7 @@ defmodule Uro.UserController do
       ok: {
         "",
         "application/json",
-        Session.json_schema()
+        Session.json_game_client_schema()
       },
       unprocessable_entity: {
         "",
@@ -226,7 +226,7 @@ defmodule Uro.UserController do
 
         json(
           conn,
-          Session.to_json_schema(session)
+          Session.to_json_game_client_schema(session)
         )
 
       {:error, conn} ->


### PR DESCRIPTION
Using `/registration` API endpoint from `godot-uro` addon correctly created user on server, but error `Malformed Request` was returned by client due to API interface mismatch.

This PR fixes error by using the expected schema.